### PR TITLE
Allow to force index.php in generateUrl

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,7 +40,8 @@ export const generateOcsUrl = (service: string, version: Number) => {
 }
 
 export interface UrlOptions {
-    escape: boolean
+    escape: boolean,
+    noRewrite: boolean
 }
 
 /**
@@ -52,7 +53,8 @@ export interface UrlOptions {
  */
 export const generateUrl = (url: string, params?: object, options?: UrlOptions) => {
     const allOptions = Object.assign({
-        escape: true
+        escape: true,
+        noRewrite: false
     }, options || {})
 
     const _build = function (text: string, vars: object) {
@@ -73,7 +75,7 @@ export const generateUrl = (url: string, params?: object, options?: UrlOptions) 
 
     }
 
-    if (OC.config.modRewriteWorking === true) {
+    if (OC.config.modRewriteWorking === true && !allOptions.noRewrite) {
         return getRootUrl() + _build(url, params || {});
     }
 


### PR DESCRIPTION
This will allow to generate an URL that always contains the index.php even if url rewrite is configured. 

An example use case is Collabora, where we always want to have the same URL generated. The backend endforces index.php to be on the save side as this will always work, so I think it makes sense to have a dedicated option for that here as well.